### PR TITLE
Support Screenboard template_variables

### DIFF
--- a/lib/doggy/models/screen.rb
+++ b/lib/doggy/models/screen.rb
@@ -3,14 +3,15 @@
 module Doggy
   module Models
     class Screen < Doggy::Model
-      attribute :id,          Integer
-      attribute :board_title, String
+      attribute :id,                 Integer
+      attribute :board_title,        String
 
-      attribute :board_bgtype, String
-      attribute :templated,    Boolean
-      attribute :widgets,      Array[Hash]
-      attribute :height,       String
-      attribute :width,        String
+      attribute :board_bgtype,       String
+      attribute :templated,          Boolean
+      attribute :template_variables, Array[Hash]
+      attribute :widgets,            Array[Hash]
+      attribute :height,             String
+      attribute :width,              String
 
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/screen".tap do |base_url|


### PR DESCRIPTION
We've had issues where after editing a screenboard, updating it rendered it broken. It was because it was using `template_variables` that were not pulled, so upon pushing it, the templates variables had to be added manually.

This fixes it by defining the attribute in the model, a pull will get the value from now on.