### PR TITLE
Added an option to push all objects and modified git pull to delete locally

### DIFF
--- a/lib/doggy/cli.rb
+++ b/lib/doggy/cli.rb
@@ -26,9 +26,10 @@ module Doggy
       the marker in their title will get it as a result of a push.
     D
 
-    method_option "dashboards", type: :boolean, desc: 'Pull dashboards'
-    method_option "monitors",   type: :boolean, desc: 'Pull monitors'
-    method_option "screens",    type: :boolean, desc: 'Pull screens'
+    method_option "dashboards",   type: :boolean, default: true, desc: 'Pull dashboards'
+    method_option "monitors",     type: :boolean, default: true, desc: 'Pull monitors'
+    method_option "screens",      type: :boolean, default: true, desc: 'Pull screens'
+    method_option "all_objects",  type: :boolean, default: false, desc: 'Push all objects even if they are not changed'
 
     def push
       CLI::Push.new(options.dup).run

--- a/lib/doggy/cli/pull.rb
+++ b/lib/doggy/cli/pull.rb
@@ -73,6 +73,11 @@ module Doggy
 
       klass.assign_paths(remote_resources, local_resources)
       remote_resources.each(&:save_local)
+
+      ids = local_resources.map(&:id) - remote_resources.map(&:id)
+      local_resources.each do |local_resource|
+        local_resource.destroy_local if ids.include?(local_resource.id)
+      end
     end
   end
 end

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -7,22 +7,18 @@ module Doggy
     end
 
     def run
-      push_resources('dashboards', Models::Dashboard) if should_push?('dashboards')
-      push_resources('monitors',   Models::Monitor)   if should_push?('monitors')
-      push_resources('screens',    Models::Screen)    if should_push?('screens')
+      push_resources('dashboards', Models::Dashboard) if @options['dashboards']
+      push_resources('monitors',   Models::Monitor)   if @options['monitors']
+      push_resources('screens',    Models::Screen)    if @options['screens']
 
       Doggy::Model.emit_shipit_deployment
     end
 
   private
 
-    def should_push?(resource)
-      @options.empty? || @options[resource]
-    end
-
     def push_resources(name, klass)
       Doggy.ui.say "Pushing #{ name }"
-      local_resources = klass.all_local(only_changed: true)
+      local_resources = klass.all_local(only_changed: !@options['all_objects'])
       local_resources.each(&:save)
     end
   end

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -2,11 +2,20 @@
 
 module Doggy
   class CLI::Push
+    WARNING_MESSAGE = "You are about to force push all the objects. "\
+      "This will override changes in Datadog if they have not been sycned to the dog repository. "\
+      "Do you want to proceed?(Y/N)"
+
     def initialize(options)
       @options = options
     end
 
     def run
+      if @options['all_objects'] && !Doggy.ui.yes?(WARNING_MESSAGE)
+        Doggy.ui.say "Operation cancelled"
+        return
+      end
+
       push_resources('dashboards', Models::Dashboard) if @options['dashboards']
       push_resources('monitors',   Models::Monitor)   if @options['monitors']
       push_resources('screens',    Models::Screen)    if @options['screens']

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -19,6 +19,7 @@ module Doggy
     def push_resources(name, klass)
       Doggy.ui.say "Pushing #{ name }"
       local_resources = klass.all_local(only_changed: !@options['all_objects'])
+      Doggy.ui.say "#{ local_resources.size } objects to push"
       local_resources.each(&:save)
     end
   end

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -209,6 +209,10 @@ module Doggy
       request(:delete, resource_url(id))
     end
 
+    def destroy_local
+      File.delete(@path)
+    end
+
     protected
 
     def resource_url(id = nil)

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -200,8 +200,10 @@ module Doggy
         attributes = request(:post, resource_url, body)
         self.id    = self.class.new(attributes).id
         save_local
+        Doggy.ui.say "Created #{ @path }"
       else
         request(:put, resource_url(id), body)
+        Doggy.ui.say "Updated #{ @path }"
       end
     end
 


### PR DESCRIPTION
1. Recently we had an issue with `doggy` that it did not deploy the modified objects in the repository(we yet to find why). I added an option to be able push all objects without relying on git diff for emergency cases.

2. `doggy pull` was not deleting remotely deleted objects locally. Modified the command accordingly to make sure it deletes objects locally.

3. Made `doggy push`more verbose.

@bai @marc-barry