### PR TITLE
make sure an object is read only after doggy push

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :test do
+  gem 'mocha'
+  gem 'webmock'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,21 +11,31 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
+    hashdiff (0.2.3)
     ice_nine (0.11.2)
     json (1.8.3)
+    metaclass (0.0.4)
     minitest (5.9.0)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     parallel (1.6.2)
+    public_suffix (2.0.4)
     rake (10.5.0)
     rugged (0.23.3)
+    safe_yaml (1.0.4)
     thor (0.19.1)
     thread_safe (0.3.5)
     virtus (1.0.5)
@@ -33,6 +43,10 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -41,7 +55,9 @@ DEPENDENCIES
   bundler (~> 1.10)
   doggy!
   minitest
+  mocha
   rake (~> 10.0)
+  webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/lib/doggy/cli/edit.rb
+++ b/lib/doggy/cli/edit.rb
@@ -9,6 +9,7 @@ module Doggy
 
     def run
       resource = resource_by_param
+      resource.read_only = false
       return Doggy.ui.error("Could not find resource with #{ @param }") unless resource
 
       Dir.chdir(File.dirname(resource.path)) do
@@ -98,7 +99,6 @@ module Doggy
 
       forked_resource = resource.dup
       forked_resource.id = nil
-      forked_resource.read_only = false
       if resource.class.to_s.downcase =~ /dashboard/
         forked_resource.title = "[#{ salt }] " + forked_resource.title
         forked_resource.description = "[fork of #{ resource.id }] " + forked_resource.title

--- a/lib/doggy/cli/edit.rb
+++ b/lib/doggy/cli/edit.rb
@@ -98,6 +98,7 @@ module Doggy
 
       forked_resource = resource.dup
       forked_resource.id = nil
+      forked_resource.read_only = false
       if resource.class.to_s.downcase =~ /dashboard/
         forked_resource.title = "[#{ salt }] " + forked_resource.title
         forked_resource.description = "[fork of #{ resource.id }] " + forked_resource.title

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -28,7 +28,7 @@ module Doggy
     def push_resources(name, klass)
       Doggy.ui.say "Pushing #{ name }"
       local_resources = klass.all_local(only_changed: !@options['all_objects'])
-      local_resources.each { |resource| resource.read_only = true }
+      local_resources.each(&:ensure_read_only!)
       Doggy.ui.say "#{ local_resources.size } objects to push"
       local_resources.each(&:save)
     end

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -28,6 +28,7 @@ module Doggy
     def push_resources(name, klass)
       Doggy.ui.say "Pushing #{ name }"
       local_resources = klass.all_local(only_changed: !@options['all_objects'])
+      local_resources.each { |resource| resource.read_only = true }
       Doggy.ui.say "#{ local_resources.size } objects to push"
       local_resources.each(&:save)
     end

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -176,7 +176,12 @@ module Doggy
       super(attributes)
     end
 
+    def ensure_read_only!
+      self.read_only = true
+    end
+
     def save_local
+      ensure_read_only!
       prefix = case self.class.name
         when 'Doggy::Models::Dashboard' then 'dash'
         when 'Doggy::Models::Monitor' then 'monitor'

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -9,6 +9,8 @@ module Doggy
   class Model
     include Virtus.model
 
+    attribute :read_only, Boolean
+
     # This stores the path on disk. We don't define it as a model attribute so
     # it doesn't get serialized.
     attr_accessor :path
@@ -193,8 +195,13 @@ module Doggy
       # NotImplemented
     end
 
+    def ensure_read_only!
+      self.read_only = true
+    end
+
     def save
       ensure_managed_emoji!
+      ensure_read_only!
       validate
 
       body = JSON.dump(to_h)

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -195,13 +195,8 @@ module Doggy
       # NotImplemented
     end
 
-    def ensure_read_only!
-      self.read_only = true
-    end
-
     def save
       ensure_managed_emoji!
-      ensure_read_only!
       validate
 
       body = JSON.dump(to_h)

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = "2.0.27"
+  VERSION = "2.0.29"
 end

--- a/test/doggy/cli/edit_test.rb
+++ b/test/doggy/cli/edit_test.rb
@@ -1,0 +1,13 @@
+require_relative '../../test_helper'
+
+class Doggy::CLI::PushTest < Minitest::Test
+  def test_run_ensures_editable
+    resource = Doggy::Models::Dashboard.new({'dash' => {'id' => 1, 'title' => 'Pipeline', 'read_only' => true}})
+    cmd = Doggy::CLI::Edit.new({}, nil)
+    resource.path = 'dummy_path'
+    Dir.expects(:chdir).with(File.dirname(resource.path))
+    cmd.expects(:resource_by_param).returns(resource)
+    cmd.run
+    refute resource.read_only
+  end
+end

--- a/test/doggy/cli/push_test.rb
+++ b/test/doggy/cli/push_test.rb
@@ -1,0 +1,15 @@
+require_relative '../../test_helper'
+
+class Doggy::CLI::PushTest < Minitest::Test
+  def test_push_ensures_read_only
+    model = Doggy::Models::Dashboard.new({'dash' => {'id' => 1, 'title' => 'Pipeline'}})
+    Doggy::Models::Dashboard.expects(:all_local).returns([model])
+    Doggy::Models::Monitor.expects(:all_local).returns([])
+    Doggy::Models::Screen.expects(:all_local).returns([])
+    stub_request(:put, "https://app.datadoghq.com/api/v1/dash/1?api_key=api_key_123&application_key=app_key_345").
+      with(:body => "{\"description\":null,\"graphs\":[],\"id\":1,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
+      to_return(:status => 200, :body => "")
+
+    Doggy::CLI::Push.new({'dashboards' => true, 'monitors' => true, 'screens' => true}).run
+  end
+end

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -10,6 +10,24 @@ class Doggy::ModelTest < Minitest::Test
     self.root = :dash
   end
 
+  def test_create
+    model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline'}})
+    stub_request(:post, 'https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345').
+        with(:body => "{\"description\":null,\"graphs\":[],\"id\":null,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
+                      to_return(:status => 200, :body => "{\"id\":1}")
+    File.expects(:open).with(Doggy.object_root.join('dash-1.json'), 'w')
+    model.save
+  end
+
+  def test_update
+    model = Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name')
+    stub_request(:put, "https://app.datadoghq.com/api/v1/monitor/1?api_key=api_key_123&application_key=app_key_345").
+      with(:body => "{\"id\":1,\"message\":null,\"multi\":null,\"name\":\"Monitor name 🐶\",\"options\":{},"\
+           "\"org_id\":null,\"query\":null,\"read_only\":true,\"tags\":[],\"type\":null}").
+      to_return(:status => 200)
+    model.save
+  end
+
   def test_sort_by_key
     h = { b: [ {d: 1, a: 2}, {x: 1, p: 3, y: 5} ], a: 3 }
     expected = { a: 3, b: [ {a: 2, d: 1}, {p: 3, x: 1, y: 5} ] }

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -10,6 +10,13 @@ class Doggy::ModelTest < Minitest::Test
     self.root = :dash
   end
 
+  def test_save_local_ensures_read_only
+    model = Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name', 'read_only' => false)
+    File.expects(:open).with(Doggy.object_root.join('monitor-1.json'), 'w')
+    model.save_local
+    assert model.read_only
+  end
+
   def test_create
     model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline', 'read_only' => true}})
     stub_request(:post, 'https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345').

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -11,7 +11,7 @@ class Doggy::ModelTest < Minitest::Test
   end
 
   def test_create
-    model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline'}})
+    model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline', 'read_only' => true}})
     stub_request(:post, 'https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345').
         with(:body => "{\"description\":null,\"graphs\":[],\"id\":null,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
                       to_return(:status => 200, :body => "{\"id\":1}")
@@ -20,7 +20,7 @@ class Doggy::ModelTest < Minitest::Test
   end
 
   def test_update
-    model = Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name')
+    model = Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name', 'read_only' => true)
     stub_request(:put, "https://app.datadoghq.com/api/v1/monitor/1?api_key=api_key_123&application_key=app_key_345").
       with(:body => "{\"id\":1,\"message\":null,\"multi\":null,\"name\":\"Monitor name 🐶\",\"options\":{},"\
            "\"org_id\":null,\"query\":null,\"read_only\":true,\"tags\":[],\"type\":null}").

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,10 +5,20 @@ require 'doggy'
 
 require 'minitest/pride'
 require 'minitest/autorun'
+require 'minitest/unit'
+require 'mocha/mini_test'
+require 'webmock/minitest'
 
-def load_fixture(fixture_path)
-  path = File.expand_path("fixtures/#{ fixture_path }", "#{ __FILE__ }/../")
-  raw  = File.read(path)
+class MiniTest::Test
+  def before_setup
+    Doggy.stubs(:secrets).returns({'datadog_api_key' => 'api_key_123', 'datadog_app_key' => 'app_key_345'})
+    super
+  end
 
-  JSON.parse(raw)
+  def load_fixture(fixture_path)
+    path = File.expand_path("fixtures/#{ fixture_path }", "#{ __FILE__ }/../")
+    raw  = File.read(path)
+
+    JSON.parse(raw)
+  end
 end


### PR DESCRIPTION
fixes https://github.com/bai/doggy/issues/16

Added a method to make sure `read_only` attribute is always set to `true` before pushing an object to Datadog.

@bai @marc-barry