### PR TITLE
make sure monitors get locked as well and add doggy push ID support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggy (2.0.29)
+    doggy (2.0.30)
       json (~> 1.8.3)
       parallel (~> 1.6.1)
       rugged (~> 0.23.2)

--- a/lib/doggy/cli.rb
+++ b/lib/doggy/cli.rb
@@ -31,8 +31,8 @@ module Doggy
     method_option "screens",      type: :boolean, default: true, desc: 'Pull screens'
     method_option "all_objects",  type: :boolean, default: false, desc: 'Push all objects even if they are not changed'
 
-    def push
-      CLI::Push.new(options.dup).run
+    def push(*ids)
+      CLI::Push.new(options.dup, ids).run
     end
 
     desc "mute OBJECT_ID OBJECT_ID OBJECT_ID", "Mutes monitor on DataDog"

--- a/lib/doggy/cli/edit.rb
+++ b/lib/doggy/cli/edit.rb
@@ -64,7 +64,7 @@ module Doggy
       salt = random_word
       forked_resource = resource.dup
       forked_resource.id = nil
-      forked_resource.read_only = false
+      forked_resource.refute_read_only!
       if resource.class.to_s.downcase =~ /dashboard/
         forked_resource.title = "[#{ salt }] " + forked_resource.title
         forked_resource.description = "[fork of #{ resource.id }] " + forked_resource.title

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -9,8 +9,6 @@ module Doggy
   class Model
     include Virtus.model
 
-    attribute :read_only, Boolean
-
     # This stores the path on disk. We don't define it as a model attribute so
     # it doesn't get serialized.
     attr_accessor :path
@@ -175,10 +173,6 @@ module Doggy
 
       attributes = attributes[root_key]
       super(attributes)
-    end
-
-    def ensure_read_only!
-      self.read_only = true
     end
 
     def save_local

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -177,12 +177,6 @@ module Doggy
 
     def save_local
       ensure_read_only!
-      prefix = case self.class.name
-        when 'Doggy::Models::Dashboard' then 'dash'
-        when 'Doggy::Models::Monitor' then 'monitor'
-        when 'Doggy::Models::Screen' then 'screen'
-        end
-
       @path ||= Doggy.object_root.join("#{prefix}-#{id}.json")
       File.open(@path, 'w') { |f| f.write(JSON.pretty_generate(to_h)) }
     end

--- a/lib/doggy/models/dashboard.rb
+++ b/lib/doggy/models/dashboard.rb
@@ -11,6 +11,11 @@ module Doggy
 
       attribute :graphs,             Array[Hash]
       attribute :template_variables, Array[Hash]
+      attribute :read_only,          Boolean
+
+      def ensure_read_only!
+        self.read_only = true
+      end
 
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/dash".tap do |base_url|

--- a/lib/doggy/models/dashboard.rb
+++ b/lib/doggy/models/dashboard.rb
@@ -21,6 +21,10 @@ module Doggy
         self.read_only = true
       end
 
+      def refute_read_only!
+        self.read_only = false
+      end
+
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/dash".tap do |base_url|
           base_url << "/#{ id }" if id

--- a/lib/doggy/models/dashboard.rb
+++ b/lib/doggy/models/dashboard.rb
@@ -13,6 +13,10 @@ module Doggy
       attribute :template_variables, Array[Hash]
       attribute :read_only,          Boolean
 
+      def prefix
+        'dash'
+      end
+
       def ensure_read_only!
         self.read_only = true
       end

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -39,6 +39,10 @@ module Doggy
       attribute :type,    String
       attribute :multi,   Boolean
 
+      def prefix
+        'monitor'
+      end
+
       def ensure_read_only!
         if options
           self.options.locked = true

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -15,6 +15,7 @@ module Doggy
         attribute :timeout_h,          Integer
         attribute :escalation_message, String
         attribute :renotify_interval,  Integer
+        attribute :locked,             Boolean
 
         def to_h
           return super unless monitor.id && monitor.loading_source == :local
@@ -37,6 +38,14 @@ module Doggy
       attribute :tags,    Array[String]
       attribute :type,    String
       attribute :multi,   Boolean
+
+      def ensure_read_only!
+        if options
+          self.options.locked = true
+        else
+          self.options = Options.new(locked: true)
+        end
+      end
 
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/monitor".tap do |base_url|

--- a/lib/doggy/models/screen.rb
+++ b/lib/doggy/models/screen.rb
@@ -12,6 +12,11 @@ module Doggy
       attribute :widgets,            Array[Hash]
       attribute :height,             String
       attribute :width,              String
+      attribute :read_only,          Boolean
+
+      def ensure_read_only!
+        self.read_only = true
+      end
 
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/screen".tap do |base_url|

--- a/lib/doggy/models/screen.rb
+++ b/lib/doggy/models/screen.rb
@@ -14,6 +14,10 @@ module Doggy
       attribute :width,              String
       attribute :read_only,          Boolean
 
+      def prefix
+        'screen'
+      end
+
       def ensure_read_only!
         self.read_only = true
       end

--- a/lib/doggy/models/screen.rb
+++ b/lib/doggy/models/screen.rb
@@ -22,6 +22,10 @@ module Doggy
         self.read_only = true
       end
 
+      def refute_read_only!
+        self.read_only = false
+      end
+
       def self.resource_url(id = nil)
         "https://app.datadoghq.com/api/v1/screen".tap do |base_url|
           base_url << "/#{ id }" if id

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = "2.0.29"
+  VERSION = "2.0.30"
 end

--- a/test/doggy/cli/edit_test.rb
+++ b/test/doggy/cli/edit_test.rb
@@ -2,43 +2,55 @@ require_relative '../../test_helper'
 
 class Doggy::CLI::PushTest < Minitest::Test
   def test_run
-    fixture = load_fixture('dashboard.json')
-    resource = Doggy::Models::Dashboard.new(fixture)
-    resource.read_only = true
-    file = Tempfile.new("dash-#{resource.id}.json")
-    resource.path = file.path
+    dashboard = Doggy::Models::Dashboard.new(load_fixture('dashboard.json'))
+    monitor = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
 
-    Doggy::Models::Dashboard.expects(:all_local).returns([resource])
-    Doggy::Models::Monitor.expects(:all_local).returns([])
-    Doggy::Models::Screen.expects(:all_local).returns([])
+    Doggy::Models::Dashboard.expects(:all_local).twice.returns([dashboard])
+    Doggy::Models::Monitor.expects(:all_local).twice.returns([monitor])
+    Doggy::Models::Screen.expects(:all_local).twice.returns([])
 
-    cmd = Doggy::CLI::Edit.new({}, resource.id.to_s)
+    [dashboard, monitor].each do |resource|
+      resource.ensure_read_only!
+      resource.path = Tempfile.new("#{resource.prefix}-#{resource.id}.json").path
 
-    forked_resource_id = 2
-    cmd.expects(:random_word).returns('randomword')
-    forked_resource_attributes = {
-      description: '[fork of 2473] [randomword] My Dashboard',
-      graphs: resource.graphs.dup,
-      id: nil,
-      read_only: false, template_variables: [], title: "[randomword] #{resource.title} \xF0\x9F\x90\xB6"
-    }
-    stub_request(:post, "https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345").
-      with(body: JSON.dump(forked_resource_attributes)).
-           to_return(status: 200, body: "{\"id\":#{forked_resource_id}}")
-    JSON.expects(:pretty_generate).with(forked_resource_attributes.merge(id: forked_resource_id, read_only: true))
-    cmd.expects(:system).with("open 'https://app.datadoghq.com/dash/#{forked_resource_id}'")
-    cmd.expects(:wait_for_edit)
+      cmd = Doggy::CLI::Edit.new({}, resource.id.to_s)
 
-    graph = resource.to_h[:graphs][0].dup
-    new_resource_attributes = resource.to_h.dup
-    new_resource_attributes[:graphs] = [graph.merge('title' => 'Not Average Memory Free anymore')]
-    stub_request(:get, "https://app.datadoghq.com/api/v1/dash/2?api_key=api_key_123&application_key=app_key_345").
-      to_return(status: 200, body: JSON.dump(new_resource_attributes.merge(id: forked_resource_id)))
-    JSON.expects(:pretty_generate).with(new_resource_attributes)
+      forked_resource_id = 2
+      cmd.expects(:random_word).returns('randomword')
+      forked_resource_attributes = resource.to_h.dup.merge(id: nil)
+      if resource.is_a?(Doggy::Models::Dashboard)
+        forked_resource_attributes.merge!(title: "[randomword] #{resource.title} \xF0\x9F\x90\xB6",
+                                          description: '[fork of 2473] [randomword] My Dashboard', read_only: false)
+      elsif resource.is_a?(Doggy::Models::Monitor)
+        forked_resource_attributes.merge!(name: "[randomword] Cache expiry \xF0\x9F\x90\xB6",
+                                          options: forked_resource_attributes[:options].merge(locked: false))
+      end
 
-    stub_request(:delete, "https://app.datadoghq.com/api/v1/dash/2?api_key=api_key_123&application_key=app_key_345").
-      to_return(status: 200)
+      forked_resource_attributes = Doggy::Model.sort_by_key(forked_resource_attributes)
+      stub_request(:post, "https://app.datadoghq.com/api/v1/#{resource.prefix}?api_key=api_key_123&application_key=app_key_345").
+        with(body: JSON.dump(forked_resource_attributes)).
+             to_return(status: 200, body: "{\"id\":#{forked_resource_id}}")
+      if resource.is_a?(Doggy::Models::Dashboard)
+        JSON.expects(:pretty_generate).with(forked_resource_attributes.merge(id: forked_resource_id, read_only: true))
+      elsif resource.is_a?(Doggy::Models::Monitor)
+        JSON.expects(:pretty_generate).with(forked_resource_attributes.merge(id: forked_resource_id, options: forked_resource_attributes[:options].merge(locked: true)))
+      end
+      cmd.expects(:system).with("open '#{resource.class.new(id: forked_resource_id).human_edit_url}'")
+      cmd.expects(:wait_for_edit)
 
-    cmd.run
+      new_resource_attributes = resource.to_h.dup
+      if resource.is_a?(Doggy::Models::Dashboard)
+        graph = new_resource_attributes[:graphs][0].dup
+        new_resource_attributes[:graphs] = [graph.merge('title' => 'Not Average Memory Free anymore')]
+      end
+      stub_request(:get, "https://app.datadoghq.com/api/v1/#{resource.prefix}/2?api_key=api_key_123&application_key=app_key_345").
+        to_return(status: 200, body: JSON.dump(new_resource_attributes.merge(id: forked_resource_id)))
+      JSON.expects(:pretty_generate).with(new_resource_attributes)
+
+      stub_request(:delete, "https://app.datadoghq.com/api/v1/#{resource.prefix}/2?api_key=api_key_123&application_key=app_key_345").
+        to_return(status: 200)
+
+      cmd.run
+    end
   end
 end

--- a/test/doggy/cli/push_test.rb
+++ b/test/doggy/cli/push_test.rb
@@ -2,14 +2,30 @@ require_relative '../../test_helper'
 
 class Doggy::CLI::PushTest < Minitest::Test
   def test_push_ensures_read_only
-    model = Doggy::Models::Dashboard.new({'dash' => {'id' => 1, 'title' => 'Pipeline'}})
-    Doggy::Models::Dashboard.expects(:all_local).returns([model])
+    resource = Doggy::Models::Dashboard.new(load_fixture('dashboard.json'))
+    Doggy::Models::Dashboard.expects(:all_local).returns([resource])
     Doggy::Models::Monitor.expects(:all_local).returns([])
     Doggy::Models::Screen.expects(:all_local).returns([])
-    stub_request(:put, "https://app.datadoghq.com/api/v1/dash/1?api_key=api_key_123&application_key=app_key_345").
-      with(:body => "{\"description\":null,\"graphs\":[],\"id\":1,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
-      to_return(:status => 200, :body => "")
+    stub_request(:put, "https://app.datadoghq.com/api/v1/dash/#{resource.id}?api_key=api_key_123&application_key=app_key_345").
+      with(body: JSON.dump(resource.to_h.merge(read_only: true, title: resource.title + " \xF0\x9F\x90\xB6")))
+      .to_return(status: 200)
 
-    Doggy::CLI::Push.new({'dashboards' => true, 'monitors' => true, 'screens' => true}).run
+    Doggy::CLI::Push.new({'dashboards' => true, 'monitors' => true, 'screens' => true}, []).run
+  end
+
+  def test_push_by_ids
+    screen = Doggy::Models::Screen.new(load_fixture('screen.json'))
+    monitor = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
+    Doggy::Models::Dashboard.expects(:all_local).returns([])
+    Doggy::Models::Monitor.expects(:all_local).returns([monitor])
+    Doggy::Models::Screen.expects(:all_local).returns([screen])
+    stub_request(:put, "https://app.datadoghq.com/api/v1/#{screen.prefix}/#{screen.id}?api_key=api_key_123&application_key=app_key_345").
+      with(body: JSON.dump(screen.to_h.merge(read_only: true, board_title: screen.board_title + " \xF0\x9F\x90\xB6"))).
+      to_return(status: 200)
+    stub_request(:put, "https://app.datadoghq.com/api/v1/#{monitor.prefix}/#{monitor.id}?api_key=api_key_123&application_key=app_key_345").
+      with(body: JSON.dump(monitor.to_h.merge(options: monitor.options.to_h.merge(locked: true), name: monitor.name + " \xF0\x9F\x90\xB6"))).
+      to_return(status: 200)
+
+    Doggy::CLI::Push.new({}, [screen.id.to_s, monitor.id.to_s]).run
   end
 end

--- a/test/doggy/cli/push_test.rb
+++ b/test/doggy/cli/push_test.rb
@@ -20,10 +20,10 @@ class Doggy::CLI::PushTest < Minitest::Test
     Doggy::Models::Monitor.expects(:all_local).returns([monitor])
     Doggy::Models::Screen.expects(:all_local).returns([screen])
     stub_request(:put, "https://app.datadoghq.com/api/v1/#{screen.prefix}/#{screen.id}?api_key=api_key_123&application_key=app_key_345").
-      with(body: JSON.dump(screen.to_h.merge(read_only: true, board_title: screen.board_title + " \xF0\x9F\x90\xB6"))).
+      with(body: JSON.dump(Doggy::Model.sort_by_key(screen.to_h.merge(read_only: true, board_title: screen.board_title + " \xF0\x9F\x90\xB6")))).
       to_return(status: 200)
     stub_request(:put, "https://app.datadoghq.com/api/v1/#{monitor.prefix}/#{monitor.id}?api_key=api_key_123&application_key=app_key_345").
-      with(body: JSON.dump(monitor.to_h.merge(options: monitor.options.to_h.merge(locked: true), name: monitor.name + " \xF0\x9F\x90\xB6"))).
+      with(body: JSON.dump(Doggy::Model.sort_by_key(monitor.to_h.merge(options: monitor.options.to_h.merge(locked: true), name: monitor.name + " \xF0\x9F\x90\xB6")))).
       to_return(status: 200)
 
     Doggy::CLI::Push.new({}, [screen.id.to_s, monitor.id.to_s]).run

--- a/test/fixtures/monitor.json
+++ b/test/fixtures/monitor.json
@@ -1,0 +1,26 @@
+{
+  "id": 22,
+  "message": "The unexpired keys growth for cache has exceeded the threshold",
+  "multi": true,
+  "name": "Cache expiry",
+  "options": {
+    "silenced": {
+    },
+    "thresholds": {
+      "critical": 500000.0,
+      "warning": 250000.0
+    },
+    "notify_audit": false,
+    "notify_no_data": false,
+    "no_data_timeframe": 480,
+    "timeout_h": 0,
+    "escalation_message": null,
+    "renotify_interval": 0
+  },
+  "org_id": 67,
+  "query": "change(avg(last_4h),last_1h):avg:redis.persist{role:app--shopify--redis--resque} by {host} > 9",
+  "tags": [
+
+  ],
+  "type": "query alert"
+}

--- a/test/fixtures/screen.json
+++ b/test/fixtures/screen.json
@@ -1,0 +1,34 @@
+{
+  "board_bgtype": "board_graph",
+  "board_title": "Something TV",
+  "height": "164",
+  "id": 10,
+  "template_variables": [
+
+  ],
+  "templated": true,
+  "widgets": [
+    {
+      "board_id": 109,
+      "title_size": 16,
+      "title": true,
+      "refresh_every": 30000,
+      "tick_pos": "50%",
+      "title_align": "left",
+      "tick_edge": "bottom",
+      "text_align": "center",
+      "title_text": "",
+      "height": 5,
+      "bgcolor": "pink",
+      "html": "Red lines are bad",
+      "y": 24,
+      "x": 0,
+      "font_size": "18",
+      "tick": true,
+      "type": "note",
+      "width": 19,
+      "auto_refresh": false
+    }
+  ],
+  "width": "100%"
+}


### PR DESCRIPTION
Apparently Datadog has a different flag for locking monitors. The PR makes sure the correct flag is used to make each object type read only.

The also introduces `doggy push ID` support.

@marc-barry @bai 